### PR TITLE
Change Subscriptions API example rrule

### DIFF
--- a/one2many/REST APIs/REST_API_Intro.ipynb
+++ b/one2many/REST APIs/REST_API_Intro.ipynb
@@ -534,7 +534,7 @@
     "            },\n",
     "            \"start_time\": \"2023-01-01T00:00:00Z\",\n",
     "            \"end_time\": \"2023-03-31T00:00:00Z\",\n",
-    "            \"rrule\": \"FREQ=DAILY\",\n",
+    "            \"rrule\": \"FREQ=MONTHLY\",\n",
     "            \"item_types\": [\"PSScene\"],\n",
     "            \"asset_types\": [\"ortho_analytic_4b\"]\n",
     "        }\n",


### PR DESCRIPTION
The current Subscriptions API example uses `"rrule": "FREQ=DAILY"` which is not supported by the api. 

The example currently returns this error: 
'invalid rrule: only FREQ=MONTHLY or FREQ=YEARLY are supported'

This commit changes the rrule from "DAILY" to "MONTHLY" to fix this issue